### PR TITLE
Algo

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ Both flavors may accomodate a formatting verb, e.g:
 {pi:%3.2f} - keyed, formatting the interpolated value as a float as with `fmt` package
 ```
 
+Group values may be interpolated, but no formatting applies. They 
+
+```
+[k2:v1,k2:v2]
+```
+
 ### Unkeyed arguments
 
 Unkeyed interpolation symbols draw one argument from logging call arguments. One argument is taken per unkeyed symbol:
@@ -80,7 +86,7 @@ log.Msg("Hi", "name", "Mulder")
 ### Escaping
 
 Because '{', '}', and ':' are used as interpolation tokens, they may need to be escaped in messages passed to logging calls.
-A '\' reads as an escape, but will itself need to be escaped in double-quoted strings.
+A '\\' reads as an escape, but will itself need to be escaped in double-quoted strings.
 
 ```
 log.Msg( "About that struct\\{\\}..." )

--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ Structured logging with string interpolation in Go
 |`text.go`| interpolation buffer ops|
 |`using.go`| configuration via Options|
 
+## TODO
+- Benchmarking - time and allocations are possible, but are there other useful metrics?
+   Size of pool (how big is a splicer relative to just a byte buffer?)
+- What about {time}, {level}, {source} interpolation keys? Anything?
+
 ## Opinions That May be Wrong
 
 Part of experimenting with `slog` is figuring out what the opinions are, and what different opinions are possible, and what the implications are. So, `logf` is trying to do some things differently just for the sake of experimenting.

--- a/_demo/aliens.go
+++ b/_demo/aliens.go
@@ -28,12 +28,12 @@ func main() {
 	for i := 0; i < width; i++ {
 		lpad := strings.Repeat(space, 10)[:i]
 		rpad := strings.Repeat(beams, 10)[:width-i]
-		progress := (100 * i) / (1.0 * width)
+		progress := (100.0 * i) / (1.0 * width)
 
 		<-time.NewTimer(40 * time.Millisecond).C
 		log.Err("{}{Scully}{}", ufo, lpad, rpad)
 
-		if i%10 == 0 {
+		if i%13 == 1 {
 			log.Level(logf.INFO+1).Msg("{}: oh no! {Scully} is {}% abducted!", "👦🏻", progress)
 		}
 	}

--- a/_demo/overload.go
+++ b/_demo/overload.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"math"
+
+	"golang.org/x/exp/slog"
+	"github.com/AndrewHarrisSPU/logf"
+)
+
+var print = logf.Print
+
+type Agent struct {
+	First string `json:"first"`
+	Last string `json:"last"`
+}
+
+func (a Agent) LogValue() slog.Value {
+	return slog.GroupValue( []slog.Attr{ slog.String( "first", a.First ), slog.String( "last", a.Last )}... )
+}
+
+func main() {
+	print( "Ya, it's possible to overload {}", "print" )
+	print( "pi is {:%.2f}", math.Pi )
+
+	mulder := Agent{ "Fox", "Mulder" }
+	print( "{}", mulder )
+}

--- a/alloc_test.go
+++ b/alloc_test.go
@@ -22,14 +22,14 @@ func TestAllocKindsSplicer(t *testing.T) {
 		verb  string
 	}{
 		{1, "string", ""},
-		{3, "string", "%10s"},
+		{1, "string", "%10s"},
 		{1, true, ""},
-		{2, true, "%-6v"},
-		{0, 1, ""},
-		{3, -1, "%+8d"},
-		{0, uint64(1), ""},
-		{0, 1.0, ""},
-		{3, 1.111, "%2.1f"},
+		{1, true, "%-6v"},
+		{1, 1, ""},
+		{1, -1, "%+8d"},
+		{1, uint64(1), ""},
+		{1, 1.0, ""},
+		{1, 1.111, "%2.1f"},
 		{1, time.Now(), ""},
 		// {2, time.Now(), time.Kitchen},
 		{1, time.Since(time.Now()), ""},
@@ -46,7 +46,7 @@ func TestAllocKindsSplicer(t *testing.T) {
 		label := fmt.Sprintf("%d: %T %s", i, f.arg, f.verb)
 		t.Run(label, func(t *testing.T) {
 			// plus one for safe freezing
-			wantAllocs(t, f.alloc, fns[i])
+			wantAllocs(t, f.alloc + 1, fns[i])
 		})
 	}
 }
@@ -71,24 +71,25 @@ func allocSplicerFunc(arg any, verb string) func() {
 
 func TestAllocKindsLogger(t *testing.T) {
 	fs := []struct {
-		alloc    int
+		argAlloc int
+		withAlloc int
 		fmtAlloc int
 		arg      any
 		verb     string
 	}{
-		{1, 1, "string", ""},
-		{3, 3, "string", "%10s"},
-		{1, 1, true, ""},
-		{2, 2, true, "%-6v"},
-		{0, 0, 1, ""},
-		{3, 3, -1, "%+8d"},
-		{0, 0, uint64(1), ""},
-		{0, 0, 1.0, ""},
-		{3, 3, 1.111, "%2.1f"},
-		{1, 1, time.Now(), ""},
+		{0, 1, 1, "string", ""},
+		{2, 2, 2, "string", "%10s"},
+		{1, 1, 1, true, ""},
+		{1, 1, 1, true, "%-6v"},
+		{0, 0, 0, 1, ""},
+		{2, 2, 2, -1, "%+8d"},
+		{0, 0, 0, uint64(1), ""},
+		{0, 0, 0, 1.0, ""},
+		{2, 2, 2, 1.111, "%2.1f"},
+		{1, 1, 1, time.Now(), ""},
 		// {2, 2, time.Now(), time.Kitchen},
-		{1, 1, time.Since(time.Now()), ""},
-		{1, 1, struct{}{}, ""},
+		{1, 1, 1, time.Since(time.Now()), ""},
+		{1, 1, 1, struct{}{}, ""},
 	}
 
 	log := setupDiscardLog()
@@ -106,13 +107,13 @@ func TestAllocKindsLogger(t *testing.T) {
 	for i, f := range fs {
 		label := fmt.Sprintf("%d: %T %s", i, f.arg, f.verb)
 		t.Run("arg "+label, func(t *testing.T) {
-			wantAllocs(t, f.alloc, argFns[i])
+			wantAllocs(t, f.argAlloc + 1, argFns[i])
 		})
 		t.Run("with "+label, func(t *testing.T) {
-			wantAllocs(t, f.alloc, withFns[i])
+			wantAllocs(t, f.withAlloc + 1, withFns[i])
 		})
 		t.Run("fmt "+label, func(t *testing.T) {
-			wantAllocs(t, f.fmtAlloc, fmtFns[i])
+			wantAllocs(t, f.fmtAlloc + 1, fmtFns[i])
 		})
 	}
 }

--- a/bench_test.go
+++ b/bench_test.go
@@ -1,0 +1,288 @@
+package logf
+
+import (
+	"errors"
+	"io"
+	"testing"
+	"time"
+
+	"golang.org/x/exp/slog"
+)
+
+func BenchmarkLoggerSize(b *testing.B){
+	// b.Run("logf manual", benchLogfInitManual)
+	b.Run("logf init", benchLogfInit)
+	b.Run("logf with 5", benchLogfWith5)
+	b.Run("logf with 10", benchLogfWith10)
+	b.Run("logf with 40", benchLogfWith40)
+	// b.Run("slog init", benchSlogInit)
+	// b.Run("slog with 5", benchSlogWith5)
+	// b.Run("slog with 10", benchSlogWith10)
+	// b.Run("slog with 40", benchSlogWith40)
+}
+
+var globalLog Logger
+var globalSlog *slog.Logger
+
+func benchLogfInitManual(b *testing.B){
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		h := &Handler{
+			seg: make([]Attr, 0),
+			ref: INFO,
+			enc: slog.NewTextHandler(io.Discard),
+			addSource: false,
+		}
+		globalLog = Logger{h, INFO}
+	}
+}
+
+func benchLogfInit(b *testing.B){
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		globalLog = New( Using.Writer(io.Discard))
+	}
+}
+
+func benchSlogInit(b *testing.B){
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		globalSlog = slog.New(slog.NewTextHandler(io.Discard))
+	}	
+}
+
+func benchLogfWith5(b *testing.B){
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = New( Using.Writer(io.Discard)).With(TestAny5...)
+	}
+}
+
+func benchLogfWith10(b *testing.B){
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = New( Using.Writer(io.Discard)).With(TestAny10...)
+	}
+}
+
+func benchLogfWith40(b *testing.B){
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = New( Using.Writer(io.Discard)).With(TestAny40...)
+	}
+}
+
+func benchSlogWith5(b *testing.B){
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = slog.New(slog.NewTextHandler(io.Discard)).With(TestAny5...)
+	}	
+}
+
+func benchSlogWith10(b *testing.B){
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = slog.New(slog.NewTextHandler(io.Discard)).With(TestAny10...)
+	}	
+}
+
+func benchSlogWith40(b *testing.B){
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = slog.New(slog.NewTextHandler(io.Discard)).With(TestAny40...)
+	}	
+}
+
+func BenchmarkAttrs(b *testing.B) {
+	for _, handler := range []struct {
+		name string
+		h    slog.Handler
+	}{
+		// {"async discard", newAsyncHandler()},
+		// {"fastText discard", newFastTextHandler(io.Discard)},
+		// {"Text discard", slog.NewTextHandler(io.Discard)},
+		{"JSON discard", slog.HandlerOptions{AddSource: false}.NewJSONHandler(io.Discard)},
+		// {"logf discard", NewHandler( Using.JSON, Using.Writer(io.Discard))},
+	} {
+		logger := slog.New(handler.h)
+		b.Run(handler.name, func(b *testing.B) {
+			for _, call := range []struct {
+				name string
+				f    func()
+			}{
+				{
+					// The number should match nAttrsInline in slog/record.go.
+					// This should exercise the code path where no allocations
+					// happen in Record or Attr. If there are allocations, they
+					// should only be from Duration.String and Time.String.
+					"5 args",
+					func() {
+						logger.LogAttrs(slog.InfoLevel, TestMessage,
+							slog.String("string", TestString),
+							slog.Int("status", TestInt),
+							slog.Duration("duration", TestDuration),
+							slog.Time("time", TestTime),
+							slog.Any("error", TestError),
+						)
+					},
+				},
+				{
+					"10 args",
+					func() {
+						logger.LogAttrs(slog.InfoLevel, TestMessage,
+							slog.String("string", TestString),
+							slog.Int("status", TestInt),
+							slog.Duration("duration", TestDuration),
+							slog.Time("time", TestTime),
+							slog.Any("error", TestError),
+							slog.String("string", TestString),
+							slog.Int("status", TestInt),
+							slog.Duration("duration", TestDuration),
+							slog.Time("time", TestTime),
+							slog.Any("error", TestError),
+						)
+					},
+				},
+				{
+					"40 args",
+					func() {
+						logger.LogAttrs(slog.InfoLevel, TestMessage,
+							slog.String("string", TestString),
+							slog.Int("status", TestInt),
+							slog.Duration("duration", TestDuration),
+							slog.Time("time", TestTime),
+							slog.Any("error", TestError),
+							slog.String("string", TestString),
+							slog.Int("status", TestInt),
+							slog.Duration("duration", TestDuration),
+							slog.Time("time", TestTime),
+							slog.Any("error", TestError),
+							slog.String("string", TestString),
+							slog.Int("status", TestInt),
+							slog.Duration("duration", TestDuration),
+							slog.Time("time", TestTime),
+							slog.Any("error", TestError),
+							slog.String("string", TestString),
+							slog.Int("status", TestInt),
+							slog.Duration("duration", TestDuration),
+							slog.Time("time", TestTime),
+							slog.Any("error", TestError),
+							slog.String("string", TestString),
+							slog.Int("status", TestInt),
+							slog.Duration("duration", TestDuration),
+							slog.Time("time", TestTime),
+							slog.Any("error", TestError),
+							slog.String("string", TestString),
+							slog.Int("status", TestInt),
+							slog.Duration("duration", TestDuration),
+							slog.Time("time", TestTime),
+							slog.Any("error", TestError),
+							slog.String("string", TestString),
+							slog.Int("status", TestInt),
+							slog.Duration("duration", TestDuration),
+							slog.Time("time", TestTime),
+							slog.Any("error", TestError),
+							slog.String("string", TestString),
+							slog.Int("status", TestInt),
+							slog.Duration("duration", TestDuration),
+							slog.Time("time", TestTime),
+							slog.Any("error", TestError),
+						)
+					},
+				},
+			} {
+				b.Run(call.name, func(b *testing.B) {
+					b.ReportAllocs()
+					b.RunParallel(func(pb *testing.PB) {
+						for pb.Next() {
+							call.f()
+						}
+					})
+				})
+			}
+		})
+	}
+}
+
+
+const TestMessage = "Test logging, but use a somewhat realistic message length."
+
+var (
+	TestTime     = time.Date(2022, time.May, 1, 0, 0, 0, 0, time.UTC)
+	TestString   = "7e3b3b2aaeff56a7108fe11e154200dd/7819479873059528190"
+	TestInt      = 32768
+	TestDuration = 23 * time.Second
+	TestError    = errors.New("fail")
+)
+
+var TestAttrs = []slog.Attr{
+	slog.String("string", TestString),
+	slog.Int("status", TestInt),
+	slog.Duration("duration", TestDuration),
+	slog.Time("time", TestTime),
+	slog.Any("error", TestError),
+}
+
+var TestAny5 = []any{
+	slog.String("string", TestString),
+	slog.Int("status", TestInt),
+	slog.Duration("duration", TestDuration),
+	slog.Time("time", TestTime),
+	slog.Any("error", TestError),
+}
+
+var TestAny10 = []any{
+	slog.String("string", TestString),
+	slog.Int("status", TestInt),
+	slog.Duration("duration", TestDuration),
+	slog.Time("time", TestTime),
+	slog.Any("error", TestError),
+	slog.String("string", TestString),
+	slog.Int("status", TestInt),
+	slog.Duration("duration", TestDuration),
+	slog.Time("time", TestTime),
+	slog.Any("error", TestError),
+}
+
+var TestAny40 = []any{
+	slog.String("string", TestString),
+	slog.Int("status", TestInt),
+	slog.Duration("duration", TestDuration),
+	slog.Time("time", TestTime),
+	slog.Any("error", TestError),
+	slog.String("string", TestString),
+	slog.Int("status", TestInt),
+	slog.Duration("duration", TestDuration),
+	slog.Time("time", TestTime),
+	slog.Any("error", TestError),
+	slog.String("string", TestString),
+	slog.Int("status", TestInt),
+	slog.Duration("duration", TestDuration),
+	slog.Time("time", TestTime),
+	slog.Any("error", TestError),
+	slog.String("string", TestString),
+	slog.Int("status", TestInt),
+	slog.Duration("duration", TestDuration),
+	slog.Time("time", TestTime),
+	slog.Any("error", TestError),
+	slog.String("string", TestString),
+	slog.Int("status", TestInt),
+	slog.Duration("duration", TestDuration),
+	slog.Time("time", TestTime),
+	slog.Any("error", TestError),
+	slog.String("string", TestString),
+	slog.Int("status", TestInt),
+	slog.Duration("duration", TestDuration),
+	slog.Time("time", TestTime),
+	slog.Any("error", TestError),
+	slog.String("string", TestString),
+	slog.Int("status", TestInt),
+	slog.Duration("duration", TestDuration),
+	slog.Time("time", TestTime),
+	slog.Any("error", TestError),
+	slog.String("string", TestString),
+	slog.Int("status", TestInt),
+	slog.Duration("duration", TestDuration),
+	slog.Time("time", TestTime),
+	slog.Any("error", TestError),
+}

--- a/bench_test.go
+++ b/bench_test.go
@@ -9,7 +9,7 @@ import (
 	"golang.org/x/exp/slog"
 )
 
-func BenchmarkLoggerSize(b *testing.B){
+func BenchmarkLoggerSize(b *testing.B) {
 	// b.Run("logf manual", benchLogfInitManual)
 	b.Run("logf init", benchLogfInit)
 	b.Run("logf with 5", benchLogfWith5)
@@ -24,73 +24,73 @@ func BenchmarkLoggerSize(b *testing.B){
 var globalLog Logger
 var globalSlog *slog.Logger
 
-func benchLogfInitManual(b *testing.B){
+func benchLogfInitManual(b *testing.B) {
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		h := &Handler{
-			seg: make([]Attr, 0),
-			ref: INFO,
-			enc: slog.NewTextHandler(io.Discard),
+			seg:       make([]Attr, 0),
+			ref:       INFO,
+			enc:       slog.NewTextHandler(io.Discard),
 			addSource: false,
 		}
 		globalLog = Logger{h, INFO}
 	}
 }
 
-func benchLogfInit(b *testing.B){
+func benchLogfInit(b *testing.B) {
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		globalLog = New( Using.Writer(io.Discard))
+		globalLog = New(Using.Writer(io.Discard))
 	}
 }
 
-func benchSlogInit(b *testing.B){
+func benchSlogInit(b *testing.B) {
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		globalSlog = slog.New(slog.NewTextHandler(io.Discard))
-	}	
-}
-
-func benchLogfWith5(b *testing.B){
-	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
-		_ = New( Using.Writer(io.Discard)).With(TestAny5...)
 	}
 }
 
-func benchLogfWith10(b *testing.B){
+func benchLogfWith5(b *testing.B) {
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		_ = New( Using.Writer(io.Discard)).With(TestAny10...)
+		_ = New(Using.Writer(io.Discard)).With(TestAny5...)
 	}
 }
 
-func benchLogfWith40(b *testing.B){
+func benchLogfWith10(b *testing.B) {
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		_ = New( Using.Writer(io.Discard)).With(TestAny40...)
+		_ = New(Using.Writer(io.Discard)).With(TestAny10...)
 	}
 }
 
-func benchSlogWith5(b *testing.B){
+func benchLogfWith40(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = New(Using.Writer(io.Discard)).With(TestAny40...)
+	}
+}
+
+func benchSlogWith5(b *testing.B) {
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		_ = slog.New(slog.NewTextHandler(io.Discard)).With(TestAny5...)
-	}	
+	}
 }
 
-func benchSlogWith10(b *testing.B){
+func benchSlogWith10(b *testing.B) {
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		_ = slog.New(slog.NewTextHandler(io.Discard)).With(TestAny10...)
-	}	
+	}
 }
 
-func benchSlogWith40(b *testing.B){
+func benchSlogWith40(b *testing.B) {
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		_ = slog.New(slog.NewTextHandler(io.Discard)).With(TestAny40...)
-	}	
+	}
 }
 
 func BenchmarkAttrs(b *testing.B) {
@@ -203,7 +203,6 @@ func BenchmarkAttrs(b *testing.B) {
 		})
 	}
 }
-
 
 const TestMessage = "Test logging, but use a somewhat realistic message length."
 

--- a/context.go
+++ b/context.go
@@ -33,7 +33,8 @@ func (l CtxLogger) Msg(ctx context.Context, msg string, args ...any) {
 	s := newSplicer()
 	defer s.free()
 
-	s.join(ctx, l.h.seg, args)
+	args = s.scan(msg, args)
+	s.join(l.h.seg, ctx, args)
 	l.h.handle(s, l.level.Level(), msg, nil, 0)
 }
 
@@ -46,7 +47,8 @@ func (l CtxLogger) Err(ctx context.Context, msg string, err error, args ...any) 
 	s := newSplicer()
 	defer s.free()
 
-	s.join(ctx, l.h.seg, args)
+	args = s.scan(msg, args)
+	s.join(l.h.seg, ctx, args)
 	l.h.handle(s, l.level.Level(), msg, err, 0)
 }
 
@@ -55,7 +57,8 @@ func (l CtxLogger) Fmt(ctx context.Context, msg string, err error, args ...any) 
 	s := newSplicer()
 	defer s.free()
 
-	s.join(ctx, l.h.seg, args)
+	args = s.scan(msg, args)
+	s.join(l.h.seg, nil, args)
 
 	s.interpolate(msg)
 

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/AndrewHarrisSPU/logf
 
 go 1.19
 
-require golang.org/x/exp v0.0.0-20221004215720-b9f4876ce741
+require golang.org/x/exp v0.0.0-20221012211006-4de253d81b95

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 golang.org/x/exp v0.0.0-20221004215720-b9f4876ce741 h1:fGZugkZk2UgYBxtpKmvub51Yno1LJDeEsRp2xGD+0gY=
 golang.org/x/exp v0.0.0-20221004215720-b9f4876ce741/go.mod h1:cyybsKvd6eL0RnXn6p/Grxp8F5bW7iYuBgsNCOHpMYE=
+golang.org/x/exp v0.0.0-20221012211006-4de253d81b95 h1:sBdrWpxhGDdTAYNqbgBLAR+ULAPPhfgncLr1X0lyWtg=
+golang.org/x/exp v0.0.0-20221012211006-4de253d81b95/go.mod h1:cyybsKvd6eL0RnXn6p/Grxp8F5bW7iYuBgsNCOHpMYE=

--- a/logger.go
+++ b/logger.go
@@ -40,6 +40,13 @@ func (l Logger) With(args ...any) Logger {
 	}
 }
 
+func (l Logger) WithScope(name string) Logger {
+	return Logger{
+		h:     l.h.withScope(name),
+		level: l.level,
+	}
+}
+
 // LOGGING METHODS
 
 // Msg logs a message
@@ -136,4 +143,19 @@ func Segment(args ...any) (seg []Attr) {
 		}
 	}
 	return
+}
+
+func scopeSegment(prefix string, seg []Attr) []Attr {
+	if prefix == "" {
+		return seg
+	}
+
+	pseg := make([]Attr, 0, len(seg))
+	for _, a := range seg {
+		pseg = append(pseg, Attr{
+			Key:   prefix + a.Key,
+			Value: a.Value,
+		})
+	}
+	return pseg
 }

--- a/logger.go
+++ b/logger.go
@@ -3,6 +3,7 @@ package logf
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"golang.org/x/exp/slog"
 )
@@ -95,6 +96,17 @@ func (l Logger) Fmt(msg string, err error, args ...any) (string, error) {
 	}
 
 	return msg, err
+}
+
+func Print(msg string, args ...any) {
+	s := newSplicer()
+	defer s.free()
+
+	args = s.scan(msg, args)
+	s.join(nil, nil, args)
+	s.interpolate(msg)
+
+	os.Stdout.WriteString(s.msg() + "\n")
 }
 
 // SEGMENT

--- a/logger_test.go
+++ b/logger_test.go
@@ -21,11 +21,12 @@ func TestMalformed(t *testing.T) {
 	want(missingArg)
 
 	log.Msg("{item}")
-	want(missingKey)
+	want(missingAttr)
 
 	log.Msg("{something")
 	want(missingRightBracket)
 
+	// only string in args - not enough for an Attr
 	log.Msg("no interpolation", "not-a-key")
 	want(missingArg)
 
@@ -33,13 +34,10 @@ func TestMalformed(t *testing.T) {
 	log.Msg("no interpolation", 0)
 	want(missingKey)
 
-	// can't interpolate from arg segment
-	log.Msg("{x}", slog.Int("x", 1))
-	want(missingKey)
-
 	// both bools appear (no deduplication)
-	log.With("bool", true).Msg("{bool}", slog.Bool("bool", false))
-	want(`"msg":"true","bool":true,"bool":false`)
+	// also: second bool wins for interpolation
+	log.With("bit", true).Msg("{bit}", slog.Bool("bit", false))
+	want(`"msg":"false","bit":true,"bit":false`)
 
 	// just the second x appears (first consumed by {} in msg)
 	log.Msg("{}", slog.Int("x", 1), slog.Int("x", 2))

--- a/logger_test.go
+++ b/logger_test.go
@@ -105,6 +105,63 @@ func TestLoggerErr(t *testing.T) {
 	}
 }
 
+func TestGroup(t *testing.T) {
+	log, want := substringTestLogger(t)
+
+	// one group
+	mulder := slog.Group("1", slog.String("first", "Fox"), slog.String("last", "Mulder"))
+	log.Msg("Hi, {1.first} {1.last}", mulder)
+	want("Hi, Fox Mulder")
+
+	// two groups
+	scully := slog.Group("2", slog.String("first", "Dana"), slog.String("last", "Scully"))
+	agents := slog.Group("agents", mulder, scully)
+	log.Msg("Hi, {agents.1.last} and {agents.2.last}", agents)
+	want("Hi, Mulder and Scully")
+
+	// raw
+	log.Msg("{}", agents)
+	want("msg=[1:[first:Fox,last:Mulder],2:[first:Dana,last:Scully]]")
+}
+
+func TestScope(t *testing.T) {
+	log, want := substringTestLogger(t)
+
+	// one scope
+	mulder := log.WithScope("agent").With("first", "Fox", "last", "Mulder")
+	mulder.Msg("Hi, {agent.last}")
+	want("Hi, Mulder")
+
+	// another scope
+	files := log.WithScope("files").With("x", true)
+	files.Msg("{files.x}")
+	want("msg=true")
+
+	// two scopes
+	log = log.WithScope("x").WithScope("agent").With("last", "Scully")
+	log.Msg("Hi, {x.agent.last}")
+	want("Hi, Scully")
+}
+
+// spoofy types to test LogValuer
+type (
+	spoof0 struct{}
+	spoof1 struct{}
+	spoof2 struct{}
+)
+
+func (s spoof0) LogValue() slog.Value {
+	return slog.StringValue("spoof")
+}
+
+func (s spoof1) LogValue() slog.Value {
+	return slog.AnyValue(spoof0{})
+}
+
+func (s spoof2) LogValue() slog.Value {
+	return slog.AnyValue(spoof1{})
+}
+
 // test correctness of interpolation and formatting
 func TestLoggerKinds(t *testing.T) {
 	fs := []struct {
@@ -135,8 +192,18 @@ func TestLoggerKinds(t *testing.T) {
 		{time.Unix(1, 0).Sub(time.Unix(0, 0)), "", "msg=1s"},
 		{time.Unix(1, 0).Sub(time.Unix(0, 999999000)), "", "msg=1µs"},
 		{time.Unix(1, 0).Sub(time.Unix(1, 0)), "", "msg=0s"},
+
 		// any fmting
 		{struct{}{}, "", "msg={}"},
+
+		// group
+		{slog.Group("row", slog.Int("A", 1), slog.Int("B", 2)), "", "msg=[A:1,B:2]"},
+
+		// LogValuer
+		{spoof0{}, "", "msg=spoof"},
+		{spoof0{}, "%10s", "msg=\"     spoof\""},
+		{spoof2{}, "", "msg=spoof"},
+		{spoof2{}, "%10s", "msg=\"     spoof\""},
 	}
 
 	log, want := substringTestLogger(t)

--- a/logger_test.go
+++ b/logger_test.go
@@ -56,6 +56,9 @@ func TestEscaping(t *testing.T) {
 	log.Msg("{:}", "foo")
 	want(`"msg":"foo"`)
 
+	log.Msg(`file\.txt`)
+	want(`"msg":"file.txt"`)
+
 	log.With("{}", "x").Msg(`{\{\}}`)
 	want(`"msg":"x"`)
 
@@ -79,6 +82,10 @@ func TestEscaping(t *testing.T) {
 
 	log.With("x:y ratio", 2).Msg(`What a funny ratio: {x\:y ratio}!`)
 	want(`"msg":"What a funny ratio: 2!"`)
+
+	// There is an extra slash introduced by JSON escaping
+	log.Msg(`\{\\`)
+	want(`"msg":"{\\"`)
 
 	// Needs JSON Handler at the moment
 	log.Err("👩‍🦰", errors.New("🛸"))

--- a/minimal.go
+++ b/minimal.go
@@ -68,6 +68,22 @@ func (m *minimal) With(seg []Attr) slog.Handler {
 	}
 }
 
+// TODO
+func (m *minimal) WithScope(name string) slog.Handler {
+	return &minimal{
+		w:   m.w,
+		mu:  m.mu,
+		seg: m.seg,
+
+		layout:    m.layout,
+		start:     m.start,
+		zeroTime:  m.zeroTime,
+		elapsed:   m.elapsed,
+		export:    m.export,
+		addSource: m.addSource,
+	}
+}
+
 func (m *minimal) Handle(r slog.Record) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/splicer.go
+++ b/splicer.go
@@ -1,16 +1,30 @@
 package logf
 
 import (
+	"bytes"
 	"context"
+	"strings"
 	"sync"
+	"unicode/utf8"
 
 	"golang.org/x/exp/slog"
 )
 
 type splicer struct {
+	// final spliced output is written to text
 	text
+
+ 	// holds parts of interpolated message that need escaping
+	unescaped []byte
+
+	// holds map of keyed interpolation symbols
 	dict
-	list
+
+	// holds list of unkeyed arguments
+	list []any 
+
+	// holds ordered list of exported attrs
+	export []Attr
 }
 
 func newSplicer() *splicer {
@@ -21,8 +35,10 @@ var spool = sync.Pool{
 	New: func() any {
 		return &splicer{
 			text: make(text, 0, 1024),
+			unescaped: make([]byte, 0, 1024),
 			dict: make(dict, 5),
-			list: list{make([]any, 0, 5), 0, 0, 0},
+			list: make([]any, 0, 5),
+			export: make([]Attr, 0, 5),
 		}
 	},
 }
@@ -32,41 +48,165 @@ func (s *splicer) free() {
 	const maxAttrSize = 128
 
 	ok := cap(s.text) < maxTextSize
-	ok = ok && (len(s.dict)+cap(s.list.args)) < maxAttrSize
+	ok = ok && (len(s.dict)+cap(s.list)+cap(s.export)) < maxAttrSize
 
 	if ok {
 		s.dict.clear()
-		s.list.clear()
+
+		// TODO: clear smarter
+		s.unescaped = s.unescaped[:0]
+		s.list = s.list[:0]
+		s.export = s.export[:0]
 
 		spool.Put(s)
 	}
 }
 
-// after acquired from pool, use join to load Attrs into a splicer
-func (s *splicer) join(ctx context.Context, seg []Attr, args []any) {
-	// reset list index
-	s.list.i = 0
+func (s *splicer) scan(msg string, args []any) []any {
+	var clip string
+	var found bool
+	var unkeyed int
+	for {
+		msg, clip, found = scanKey(msg)
+		if !found {
+			break
+		}
 
-	// seg
-	// no list insert, because segment is exported by Handler
-	for _, a := range seg {
-		s.dict.insert(a)
+		key := s.scanSplitKey(clip)
+		if len(key) > 0 {
+			key = s.unescape(key)
+			s.dict.prematch(key)
+		} else {
+			unkeyed++
+		}
 	}
 
-	// args
-	// no dictionry insert, args must interpolate with "{}"" tokens
-	for len(args) > 0 {
-		s.list.insert(args[0])
+	for i := 0; i < unkeyed; i++ {
+		if len(args) == 0 {
+			s.list = append(s.list, missingArg)
+			continue
+		}
+		s.list = append(s.list, args[0])
 		args = args[1:]
 	}
 
-	// ctx
-	// insert in list to export context segment
+	return args
+}
+
+// TODO: micro-optimizing allocs etc. here could be possible.
+// putting it off for now.
+func (s *splicer) unescape(key string)(ukey string ){
+	// TODO: is this worth it?
+	if !strings.ContainsRune(key, '\\' ){
+		return key
+	}
+
+	lpos := len(s.unescaped)
+	var esc bool
+	for _, r := range key {
+		if r == '\\' && !esc {
+			esc = true
+			continue
+		}
+		esc = false
+		s.unescaped = utf8.AppendRune(s.unescaped, r)
+	}
+	rpos := len(s.unescaped)
+
+	return string(s.unescaped[lpos:rpos])
+
+	// TODO: this hould be safe
+
+	// u := s.unescaped[lpos:rpos]
+	// uHeader := (*reflect.SliceHeader)(unsafe.Pointer(&u))
+	// uKeyHeader := (*reflect.StringHeader)(unsafe.Pointer(&ukey))
+	// uKeyHeader.Data, uKeyHeader.Len = uHeader.Data, uHeader.Len
+	// return
+}
+
+func scanKey(msg string) (tail, clip string, found bool) {
+	var lpos, rpos int
+
+	if tail, lpos = scanEscape( msg, '{'); lpos < 0 {
+		return "", "", false
+	}
+	lpos++
+
+	if tail, rpos = scanEscape( tail, '}'); rpos < 0 {
+		return "", "", false
+	}
+	rpos++
+
+	tail = msg[lpos+rpos:]
+	clip = msg[lpos:lpos+rpos-1]
+	found = true
+	return
+}
+
+func scanEscape(msg string, sep rune)( tail string, n int){
+	var esc bool
+	for n, r := range msg {
+		switch {
+		case esc:
+			esc = false
+			fallthrough
+		default:
+		case r == '\\':
+			esc = true
+		case r == sep:
+			return msg[n+1:], n
+		}
+	}
+	return "", -1
+}
+
+// count unkeyed, basically
+func (s *splicer) scanSplitKey(clip string) (key string){
+	n := bytes.LastIndexByte([]byte(clip), ':')
+
+	// no colon, no verb
+	if n < 0 {
+		// the unique string that is unkeyed with no verb -> unkeyed
+		if clip == "{}" {
+			return ""
+		}
+		// otherwise -> keyed
+		return clip
+	}
+
+	// colon in 0-pos can't be escaped
+	// -> unkeyed
+	if n == 0 {
+		return ""
+	}
+
+	// last colon escaped
+	// -> clip is key
+	if clip[n-1] == '\\' {
+		return s.unescape(clip)
+	}
+
+	// last colon unescaped
+	// -> clip up to n is key
+	return s.unescape(clip[:n])
+}
+
+func (s *splicer) join(seg []Attr, ctx context.Context, args []any) {
+	for _, a := range seg {
+		s.dict.match(a)
+	}
+
+	ex := Segment(args...)
+	for _, a := range ex {
+		s.dict.match(a)
+	}
+	s.export = append(s.export, ex...)
+
 	if ctx != nil {
 		if as, ok := ctx.Value(segmentKey{}).([]Attr); ok {
 			for _, a := range as {
-				s.dict.insert(a)
-				s.list.insert(a)
+				s.dict.match(a)
+				s.export = append(s.export, a )
 			}
 		}
 	}
@@ -92,6 +232,16 @@ func (s *splicer) msg() (msg string) {
 
 type dict map[string]slog.Value
 
+func (d dict) prematch(k string){
+	d[k] = slog.StringValue(missingAttr)
+}
+
+func (d dict) match(a Attr){
+	if _, found := d[a.Key]; found {
+		d[a.Key] = a.Value
+	}
+}
+
 func (d dict) insert(a Attr) {
 	d[a.Key] = a.Value
 }
@@ -102,92 +252,21 @@ func (d dict) clear() {
 	}
 }
 
-// keeps index in i, elements in as
-type list struct {
-	args                  []any
-	i, attrBegin, attrEnd int
-}
-
-func (l *list) insert(arg any) {
-	if l.i < len(l.args) {
-		l.args[l.i] = arg
-	} else {
-		l.args = append(l.args, arg)
-	}
-	l.i++
-}
-
-func (l *list) nextArg() (arg any, ok bool) {
-	if l.i >= len(l.args) {
-		return
-	}
-
-	arg, ok = l.args[l.i], true
-	l.i++
-	return
-}
-
-func (l *list) parseAttrs() (ok bool) {
-	l.attrBegin, l.attrEnd = l.i, l.i
-
-	for l.i < len(l.args) {
-		switch arg := l.args[l.i].(type) {
-		case string:
-			if len(l.args[l.i:]) == 1 {
-				l.args[l.attrEnd] = slog.String(missingArg, arg)
-				l.attrEnd++
-				return false
-			}
-			l.args[l.attrEnd] = slog.Any(arg, l.args[l.i+1])
-			l.attrEnd++
-			l.i += 2
-		case Attr:
-			l.args[l.attrEnd] = arg
-			l.attrEnd++
-			l.i++
-		default:
-			l.args[l.attrEnd] = slog.Any(missingKey, arg)
-			l.attrEnd++
-			l.i++
-		}
-	}
-	return true
-}
-
-func (l *list) export(r *slog.Record) {
-	for i := l.attrBegin; i < l.attrEnd; i++ {
-		r.AddAttrs(l.args[i].(Attr))
-	}
-}
-
-func (l *list) clear() {
-	for i := range l.args {
-		l.args[i] = any(nil)
-	}
-	l.args = l.args[:0]
-	l.i, l.attrBegin, l.attrEnd = 0, 0, 0
-}
-
 // INTERPOLATE
 
 func (s *splicer) interpolate(msg string) {
-	s.list.i = 0
-
 	// interpolation loop
-	var clip string
-	var ok bool
+	var clip []byte
+	var found bool
 	for {
-		if msg, clip, ok = s.text.scanKey(msg); !ok {
+		if msg, clip, found = s.text.scanKey(msg); !found {
 			break
 		}
 		s.interpAttr(clip)
 	}
-
-	// remaing args -> exports
-	s.parseAttrs()
 }
 
-func (s *splicer) interpAttr(clip string) {
+func (s *splicer) interpAttr(clip text) {
 	key, verb := splitVerb(clip)
 
 	if len(key) == 0 {
@@ -197,12 +276,16 @@ func (s *splicer) interpAttr(clip string) {
 	}
 }
 
-func (s *splicer) interpUnkeyed(verb string) {
-	arg, ok := s.list.nextArg()
-	if !ok {
+func (s *splicer) interpUnkeyed(verb text) {
+	var arg any
+	if len(s.list) > 0 {
+		arg = s.list[0]
+		s.list = s.list[1:]
+	} else {
 		s.text.appendString(missingArg)
 		return
 	}
+
 	if a, isAttr := arg.(Attr); isAttr {
 		s.text.appendValue(a.Value, verb)
 		return
@@ -211,22 +294,12 @@ func (s *splicer) interpUnkeyed(verb string) {
 	s.text.appendArg(arg, verb)
 }
 
-func (s *splicer) interpKeyed(key, verb string) {
-	switch string(key) {
-	case "time":
-		// s.text.appendTimeNow(verb)
-		return
-	case "level":
-		// TODO
-		return
-	case "source":
-		// TODO
-		return
-	}
-
+func (s *splicer) interpKeyed(key, verb text) {
 	v, ok := s.dict[string(key)]
+
+	// TODO: should be unreachable, but I kept reaching it
 	if !ok {
-		s.text.appendString(missingKey)
+		s.text.appendString(missingAttr)
 		return
 	}
 

--- a/splicer2.go
+++ b/splicer2.go
@@ -1,0 +1,54 @@
+package logf
+
+import (
+	"strings"
+
+	"golang.org/x/exp/slog"
+)
+
+type dict map[string]slog.Value
+
+func (d dict) prematch(k string) {
+	d[k] = slog.StringValue(missingAttr)
+}
+
+func (d dict) match(a Attr) {
+	if _, found := d[a.Key]; found {
+		d[a.Key] = a.Value
+	}
+	if a.Value.Kind() == slog.GroupKind {
+		d.matchRec([]string{}, a)
+	}
+}
+
+func (d dict) insert(a Attr) {
+	d[a.Key] = a.Value
+}
+
+func (d dict) clear() {
+	for k := range d {
+		delete(d, k)
+	}
+}
+
+func (d dict) matchRec(keys []string, a Attr) {
+	keys = append(keys, a.Key)
+
+	for _, a := range a.Value.Group() {
+		// recurse for GroupKind
+		if a.Value.Kind() == slog.GroupKind {
+			d.matchRec(keys, a)
+		}
+
+		// push key
+		keys = append(keys, a.Key)
+
+		key := strings.Join(keys, ".")
+		if _, found := d[key]; found {
+			d[key] = a.Value
+		}
+
+		// pop key
+		keys = keys[:len(keys)-1]
+	}
+}

--- a/testutil.go
+++ b/testutil.go
@@ -51,6 +51,11 @@ func (d *discardSink) With(as []Attr) slog.Handler {
 	return &discardSink{concat(d.as, as)}
 }
 
+// TODO
+func (d *discardSink) WithScope(string) slog.Handler {
+	return d
+}
+
 // DIFF
 
 func setupDiffLog() *diffLogger {

--- a/text.go
+++ b/text.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"strconv"
-	"strings"
 	"unicode/utf8"
 
 	"golang.org/x/exp/slog"
@@ -12,6 +11,7 @@ import (
 
 const (
 	corruptKind         = "!corrupt-kind"
+	missingAttr			= "!missing-attr"
 	missingArg          = "!missing-arg"
 	missingKey          = "!missing-key"
 	missingRightBracket = "!missing-right-bracket"
@@ -22,27 +22,34 @@ type text []byte
 
 // SCAN
 
-func (t *text) scanKey(msg string) (tail string, clip string, ok bool) {
+// scan into unescaped left/right bracket pairs
+// if a key is found, clip holds key:verb text.
+func (t *text) scanKey(msg string) (tail string, clip []byte, found bool) {
 	var lpos, rpos int
+
 	if msg, lpos = t.escapeUntil(msg, '{'); lpos < 0 {
-		return "", "", false
+		return "", nil, false
 	}
 
 	if msg, rpos = t.escapeUntil(msg, '}'); rpos < 0 {
 		*t = append((*t)[:lpos], missingRightBracket...)
-		return "", "", false
+		return "", nil, false
 	}
 
-	*t, clip = (*t)[:lpos], string((*t)[lpos:])
+	// split clip from text
+	*t, clip = (*t)[:lpos], (*t)[lpos:]
 	return msg, clip, true
 }
 
+// while escaping `\`, write message runes to text
+// until sep is found, or msg is exahusted
 func (t *text) escapeUntil(msg string, sep rune) (tail string, n int) {
 	var esc bool
 	for n, r := range msg {
 		switch {
 		case esc:
 			esc = false
+			// special case: preserve the `\` from escaping a colon
 			if r == ':' {
 				t.appendString(`\:`)
 				continue
@@ -59,37 +66,55 @@ func (t *text) escapeUntil(msg string, sep rune) (tail string, n int) {
 	return "", -1
 }
 
-func splitVerb(clip string) (key, verb string) {
-	n := bytes.LastIndexByte([]byte(clip), ':')
+// unescape colons in key
+// always writes len(key) or less bytes
+func unescapeColon(key []byte) text {
+	var esc bool
+	var n int
+	for _, c := range key {
+		if c == '\\' && !esc {
+			esc = true
+			continue
+		}
+		esc = false
 
-	// no colon found
-	if n < 0 {
-		key, verb = clip, ""
-		return
+		// (invariantly, n is not larger than index)
+		key[n] = c
+		n++
 	}
 
-	// colon in 0-pos can't be escaped.
-	// interpret entire clip as emtpy key, colon as formatting token, rest of clip as verb
-	if n == 0 {
-		key, verb = "", clip[1:]
-		return
-	}
-
-	// if colon is found, but prior rune is '\'
-	// interpret entire clip as key string
-	if clip[n-1] == '\\' {
-		key, verb = colonUnescape(clip), ""
-		return
-	}
-
-	// unescaped colon means colon is formatting token
-	// clip before n is key, clip after n is verb
-	key, verb = colonUnescape(clip[:n]), clip[n+1:]
-	return
+	// key, sans-escapes, is of length n
+	return key[:n]
 }
 
-func colonUnescape(s string) string {
-	return strings.ReplaceAll(s, `\:`, `:`)
+func splitVerb(clip []byte) (key, verb []byte) {
+	n := bytes.LastIndexByte(clip, ':')
+
+	// no colon found
+	// -> no verb
+	if n < 0 {
+		key, verb = clip, nil
+		return
+	}
+
+	// colon in 0-pos can't be escaped
+	// -> no key
+	if n == 0 {
+		key, verb = nil, clip[1:]
+		return
+	}
+
+	// last colon is escaped
+	// -> no verb
+	if clip[n-1] == '\\' {
+		key, verb = unescapeColon(clip), nil
+		return
+	}
+
+	// colon found at n
+	// -> key up to n, verb after n
+	key, verb = unescapeColon(clip[:n]), clip[n+1:]
+	return
 }
 
 // APPEND
@@ -107,14 +132,14 @@ func (t *text) appendString(s string) {
 	*t = append(*t, s...)
 }
 
-func (t *text) appendArg(arg any, verb string) {
+func (t *text) appendArg(arg any, verb text) {
 	v := slog.AnyValue(arg)
 	t.appendValue(v, verb)
 }
 
-func (t *text) appendValue(v slog.Value, verb string) {
+func (t *text) appendValue(v slog.Value, verb text) {
 	if len(verb) > 0 {
-		t.appendValueVerb(v, verb)
+		t.appendValueVerb(v, string(verb))
 	} else {
 		t.appendValueNoVerb(v)
 	}


### PR DESCRIPTION
1) Groups and scopes are working. Less allocation is still possible I think, more testing seems prudent.

2) Algorithm change - using one scan through a message to create prematched dict entries, and completing matching when joining (handler segment, context, arguments). Some details:

With:
- m is the number of keyed interpolations
- and n is the number of Attrs that are candidates for keyed interpolation

The current algo is O(m*n)-ish.

Experimentation with an algorithm that is O(max(m,n)) shouldn't be difficult . The idea is to keep two sorted lists, one by interpolation key strings and Attr key strings, and walk them in unison - the same idea as how Go's runtime fills out interface method tables.

Because of expected smallness of m (more than a few would be unusual) and n (40 is the large size from slog's testing), I'm not sure how sorting benchmarks for expected cases, and how that might balance with pathological cases - it'd be measurable with testing.